### PR TITLE
Improve BEiT-3

### DIFF
--- a/src/transformers/models/beit3/configuration_beit3.py
+++ b/src/transformers/models/beit3/configuration_beit3.py
@@ -25,20 +25,20 @@ BEIT3_PRETRAINED_CONFIG_ARCHIVE_MAP = {
 
 class Beit3Config(PretrainedConfig):
     r"""
-    This is the configuration class to store the configuration of a [`Beit3Model`]. It is used to instantiate an BEiT3
+    This is the configuration class to store the configuration of a [`Beit3Model`]. It is used to instantiate a BEiT3
     model according to the specified arguments, defining the model architecture. Instantiating a configuration with the
     defaults will yield a similar configuration to that of the BEiT3
     [microsoft/beit3-base-patch16-224-pt22k](https://huggingface.co/microsoft/beit3-base-patch16-224-pt22k)
     architecture.
 
     Args:
-        embed_dim (`int`, *optional*, defaults to 768):
-            Dimensionality of the Embedding.
+        hidden_size (`int`, *optional*, defaults to 768):
+            Dimensionality of the encoder layers and the pooler layer.
         num_attention_heads (`int`, *optional*, defaults to 12):
             Number of attention heads for each attention layer in the Transformer encoder.
-        hidden_size (`int`, *optional*, defaults to 3072):
-            Dimensionality of the encoder layers and the pooler layer.
-        layers (`int`, *optional*, defaults to 12):
+        intermediate_size (`int`, *optional*, defaults to 3072):
+            Dimensionality of the "intermediate" (i.e., feed-forward) layer in the Transformer encoder.
+        num_hidden_layers (`int`, *optional*, defaults to 12):
             Number of hidden layers in the Transformer encoder.
         encoder_normalize_before (`bool`, *optional*, defaults to `False`):
             Whether to normalize before the encoder block.
@@ -55,14 +55,15 @@ class Beit3Config(PretrainedConfig):
             The dropout probability of the activation layer.
         sub_layernorm (`bool`, *optional*, defaults to `True`):
             Whether to apply sub layer norm
-        max_source_positions (`int`, *optional*, defaults to 1024):
-            The maximum sequence length of text.
+        max_position_embeddings (`int`, *optional*, defaults to 1024):
+            The maximum sequence length that this model might ever be used with. Typically set this to something large
+            just in case (e.g., 512 or 1024 or 2048).
         layer_norm_eps (`float`, *optional*, defaults to 1e-05):
             The epsilon used by the layer normalization layers.
         vocab_size (`int`, *optional*, defaults to 64010):
             Vocabulary size of the BEiT3 model. Defines the number of different image tokens that can be used during
             pre-training
-        img_size (`int`, *optional*, defaults to 224):
+        image_size (`int`, *optional*, defaults to 224):
             The size (resolution) of each image.
         patch_size (`int`, *optional*, defaults to 16):
             The size (resolution) of each patch.
@@ -94,10 +95,10 @@ class Beit3Config(PretrainedConfig):
 
     def __init__(
         self,
-        embed_dim=768,
+        hidden_size=768,
         num_attention_heads=12,
-        hidden_size=3072,
-        layers=12,
+        intermediate_size=3072,
+        num_hidden_layers=12,
         encoder_normalize_before=False,
         normalize_before=False,
         activation_fn="gelu",
@@ -105,10 +106,10 @@ class Beit3Config(PretrainedConfig):
         attention_dropout=0.0,
         activation_dropout=0.0,
         sub_layernorm=True,
-        max_source_positions=1024,
+        max_position_embeddings=1024,
         layer_norm_eps=1e-5,
         vocab_size=64010,
-        img_size=224,
+        image_size=224,
         patch_size=16,
         num_channels=3,
         initializer_range=0.02,
@@ -118,10 +119,10 @@ class Beit3Config(PretrainedConfig):
     ):
         super().__init__(**kwargs)
 
-        self.embed_dim = embed_dim
-        self.num_attention_heads = num_attention_heads
         self.hidden_size = hidden_size
-        self.layers = layers
+        self.num_attention_heads = num_attention_heads
+        self.intermediate_size = intermediate_size
+        self.num_hidden_layers = num_hidden_layers
         self.normalize_before = normalize_before
         self.encoder_normalize_before = encoder_normalize_before
         self.activation_fn = activation_fn
@@ -129,12 +130,12 @@ class Beit3Config(PretrainedConfig):
         self.attention_dropout = attention_dropout
         self.activation_dropout = activation_dropout
         self.sub_layernorm = sub_layernorm
-        self.max_source_positions = max_source_positions
+        self.max_position_embeddings = max_position_embeddings
         self.initializer_range = initializer_range
         # Text
         self.vocab_size = vocab_size
         # Vision
-        self.img_size = img_size
+        self.image_size = image_size
         self.patch_size = patch_size
         self.num_channels = num_channels
 

--- a/src/transformers/models/beit3/convert_beit3_unilm_to_pytorch.py
+++ b/src/transformers/models/beit3/convert_beit3_unilm_to_pytorch.py
@@ -88,7 +88,7 @@ def get_large_config_image_classification():
     id2label, label2id = get_id2label_for_imagenet_1k()
     return Beit3Config(
         embed_dim=1024,
-        layers=24,
+        num_hidden_layers=24,
         num_attention_heads=16,
         hidden_size=1024 * 4,
         num_labels=1000,
@@ -106,7 +106,7 @@ def get_large_config_vqa(img_size):
     id2label, label2id = get_id2label_for_vqa()
     return Beit3Config(
         embed_dim=1024,
-        layers=24,
+        num_hidden_layers=24,
         num_attention_heads=16,
         hidden_size=1024 * 4,
         num_labels=3129,
@@ -136,7 +136,7 @@ def get_large_config_visual_reasoning(img_size):
     label2id = {v: k for k, v in id2label.items()}
     return Beit3Config(
         embed_dim=1024,
-        layers=24,
+        num_hidden_layers=24,
         num_attention_heads=16,
         hidden_size=1024 * 4,
         num_labels=2,
@@ -157,7 +157,7 @@ def get_base_config_captioning(img_size):
 def get_large_config_captioning(img_size):
     return Beit3Config(
         embed_dim=1024,
-        layers=24,
+        num_hidden_layers=24,
         num_attention_heads=16,
         hidden_size=1024 * 4,
         num_labels=2,
@@ -176,7 +176,7 @@ def get_base_config_image_text_retrieval(img_size):
 def get_large_config_image_text_retrieval(img_size):
     return Beit3Config(
         embed_dim=1024,
-        layers=24,
+        num_hidden_layers=24,
         num_attention_heads=16,
         hidden_size=1024 * 4,
         num_labels=2,
@@ -346,13 +346,12 @@ if __name__ == "__main__":
         "--beit3_model_type",
         default=None,
         type=str,
-        help="Beit3 model type, it has to be one of image_classification, vqa,visual_reasoning,"
+        help="Beit3 model type, it has to be one of image_classification, vqa, visual_reasoning,"
         "image_captioning,image_text_retrieval",
     )
     parser.add_argument(
         "--validate_logits",
-        default=False,
-        type=bool,
+        action="store_false",
         help="whether to assert logits outputs",
     )
     args = parser.parse_args()

--- a/src/transformers/models/beit3/modeling_beit3.py
+++ b/src/transformers/models/beit3/modeling_beit3.py
@@ -276,7 +276,7 @@ class Beit3MultiwayFeedForwardNetwork(nn.Module):
         return torch.cat([text_out, image_out], dim=self.dim)
 
 
-class Beit3AttentiionLinear(nn.Module):
+class Beit3AttentionLinear(nn.Module):
     def __init__(self, config):
         super().__init__()
         self.text = nn.Linear(config.hidden_size, config.hidden_size, bias=True)
@@ -399,10 +399,10 @@ class Beit3MultiheadAttention(nn.Module):
         self.head_dim = self.embed_dim // self.num_heads
         self.scaling = self.head_dim**-0.5
 
-        self.key_proj = Beit3AttentiionLinear(config)
-        self.value_proj = Beit3AttentiionLinear(config)
-        self.query_proj = Beit3AttentiionLinear(config)
-        self.out_proj = Beit3AttentiionLinear(config)
+        self.key_proj = Beit3AttentionLinear(config)
+        self.value_proj = Beit3AttentionLinear(config)
+        self.query_proj = Beit3AttentionLinear(config)
+        self.out_proj = Beit3AttentionLinear(config)
         self.inner_attn_ln = Beit3LayerNorm(config) if config.sub_layernorm else None
         self.dropout_module = nn.Dropout(config.attention_dropout)
 


### PR DESCRIPTION
# What does this PR do?

This PR improves the BEiT-3 PR by making it more Transformers compliant:

- make sure all models accept both `output_hidden_states` and `output_attentions`. BEiT-3 is a regular Transformer model, very similar to BERT, hence it should support both flags
- remove relative position bias since it doesn't seem to be used
- make sure config attributes are consistent with other models in the library: rename `embed_dim` to `hidden_size`, `layers` to `num_hidden_layers`, `hidden_size` to `intermediate_size` etc.
- remove `Beit3ModelOutput` and use `BaseModelOutput` instead

To do:

- [ ] consistent API for all models. Some of them seem to accept text_padding_mask, others don't. We need to make sure all models have the same keyword arguments, in the same order.